### PR TITLE
Fix POST, PUT, DELETE method of idea-member

### DIFF
--- a/Postman/IdeaMember.postman_collection.json
+++ b/Postman/IdeaMember.postman_collection.json
@@ -1,0 +1,527 @@
+{
+	"info": {
+		"_postman_id": "f95e39a7-3e0a-4e9b-bc53-dc59ed7b93f3",
+		"name": "IdeaMember",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "http://localhost:8787/api/ideaMember/all",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/all",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"all"
+					]
+				},
+				"description": "GET all idea-member successfully"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/103",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/103",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"103"
+					]
+				},
+				"description": "Get idea-member by (ideaId, memberId)"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/aaa",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/aaa",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"aaa"
+					]
+				},
+				"description": "GET idea-member by (ideaId, memberId) FAILED\nideaId/memberId must be a number"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/111",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/111",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"111"
+					]
+				},
+				"description": "GET idea-member by (ideaId, memberId)\n(ideaId, memberId) does not exist (404)"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"ideaId\": \"1001\",\n\t\"memberId\": \"101\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "POST new idea-member succesfully"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"ideaId\": \"1001\",\n\t\"memberId\": \"103\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Add new idea-member FAILED\nidea-member already exists"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"ideaId\": \"1001\",\n\t\"memberId\": \"aaa\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Add new idea-member FAILED\nParameter is not a number"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1001\",\n\t\"newIdeaId\": \"1004\",\n\t\"oldMemberId\": \"101\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update memberId of idea-member succesfully"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1004\",\n\t\"newIdeaId\": null,\n\t\"oldMemberId\": \"101\",\n\t\"newMemberId\": \"103\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update ideaId of idea-member successfully"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1004\",\n\t\"newIdeaId\": null,\n\t\"oldMemberId\": \"101\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update idea-member FAILED\nBoth ideaId & memberId are NULL"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1004\",\n\t\"newIdeaId\": \"\",\n\t\"oldMemberId\": \"101\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update idea-member FAILED\nideaId or memberID is an empty string (\"\")"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1004\",\n\t\"newIdeaId\": \"abc\",\n\t\"oldMemberId\": \"101\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update idea-member FAILED\nideaId or memberId must be a number"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1004\",\n\t\"newIdeaId\": \"1001\",\n\t\"oldMemberId\": \"103\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update idea-member FAILED\nIdea-member existed already"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"oldIdeaId\": \"1003\",\n\t\"newIdeaId\": \"1002\",\n\t\"oldMemberId\": \"103\",\n\t\"newMemberId\": null\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						""
+					]
+				},
+				"description": "Update idea-member FAILED\nCannot find idea-member to update"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/103",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/103",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"103"
+					]
+				},
+				"description": "Delete idea-member succesfully"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/111",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/111",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"111"
+					]
+				},
+				"description": "Delete FAILED\nCannot find idea-member with (ideaId, memberId) to delete"
+			},
+			"response": []
+		},
+		{
+			"name": "http://localhost:8787/api/ideaMember/1001/aaa",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8787/api/ideaMember/1001/aaa",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8787",
+					"path": [
+						"api",
+						"ideaMember",
+						"1001",
+						"aaa"
+					]
+				},
+				"description": "Delete FAILED\nparameters must be number"
+			},
+			"response": []
+		}
+	]
+}

--- a/src/routes/api/ideaMember.js
+++ b/src/routes/api/ideaMember.js
@@ -51,7 +51,12 @@ ideaMember.get("/:ideaId/:memberId", (req, res) => {
 // example request body { "ideaId": "1001", "memberId": "101" }
 ideaMember.post("/", (req, res, next) => {
   let { ideaId, memberId } = req.body;
-  return knex
+
+  const updateCondition = (!isNaN(Number(ideaId)) && Number(ideaId) !== 0
+                          && !isNaN(Number(memberId)) && Number(memberId) !== 0)
+
+  if (updateCondition) {
+    return knex
     .select("ideaId", "memberId")
     .from("Idea_Member")
     .where({ ideaId,  memberId })
@@ -77,6 +82,12 @@ ideaMember.post("/", (req, res, next) => {
         next(err);
       }
     });
+  } else {
+    const errorMessage = "Parameters must be number!"
+    const error = new Error(errorMessage)
+    res.status(422).end(error.message)
+  }
+  
 });
 
 // PUT update idea-member (update ideaId OR memberId)


### PR DESCRIPTION
## Description
Modify POST, PUT & DELETE method of idea-member 
Add GET idea-member by (ideaId, memberId)

## How to test
### **POST method:**
POST http://localhost:8787/api/ideaMember/
Example request body: `{ "ideaId": "1001", "memberId": "101" }`

### **PUT method**
PUT http://localhost:8787/api/ideaMember/

**Rules for updating idea-member:**

- User can only update member **OR** idea at a time.
- If updating member, newIdeaId will be null in request body. If updating idea, newMemberId will be null in request body.
- newMemberId & newIdeaId cannot be null at the same time (because then, nothing is to be updated!)
- Updating data (newMemberId or newIdeaId) cannot be an empty string (""), string of other characters than number ("abc", "ax?")

1/ Example request body for updating ideaId: 
`{ "oldIdeaId": "1001", "newIdeaId": "1003", "oldMemberId": "103", "newMemberId": null } `

2/ Example request body for updating memberId: 
`{ "oldIdeaId": "1004", "newIdeaId": null, "oldMemberId": "102", "newMemberId": "101" }`

### **DELETE method**
DELETE http://localhost:8787/api/ideaMember/:ideaId/:memberId
Example: http://localhost:8787/api/ideaMember/1001/103

### **GET by (ideaId, memberId)**
GET http://localhost:8787/api/ideaMember/ideaId/memberId
Example: http://localhost:8787/api/ideaMember/1001/103